### PR TITLE
Added support for any type at root of JSON file

### DIFF
--- a/Classes/main.rct
+++ b/Classes/main.rct
@@ -9,7 +9,7 @@ namespace Json;
 #attach("lexer.rct");
 #attach("parser.rct");
 
-set function ParseJson(json string) JsonObject
+set function ParseJson(json string) JsonEntry
 {
 	var lexer <- make Lexer(json);
 	var tokens <- lexer->Lex();

--- a/Classes/parser.rct
+++ b/Classes/parser.rct
@@ -1,6 +1,6 @@
 class Parser
 {
-	set root <- make JsonObject();
+	set root <- make JsonEntry();
 	set TokenArr tokens;
 
 	set Pointer <- 0;
@@ -10,17 +10,10 @@ class Parser
 		tokens <- toks;
 	}
 
-	set function Parse() JsonObject
+	set function Parse() JsonEntry
 	{
-		if (Current()->Type != TokenType->OpenBrace)
-		{
-			Print("[JSON] MISSING ROOT OBJECT!");
-			die(-1);
-			return root;
-		}
-
-		root <- ParseObject();
-
+		// JSON allows ANY datatype to be at root, as of RFC 7158.
+		root <- ParseValue();
 		return root;
 	}
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@ package dll Json;
 var myJsonText <- "{}";
 var parsedJson <- Json::ParseJson(myJsonText);
 ```
-The `ParseJson()` function will return an object of type `JsonObject`  
-To get data from it you can use these functions:
+The `ParseJson()` function will return an object of type `JsonEntry`.
+
+The object contains two properties, `Type` and `Value`. In most cases `Type` will be `JsonObject`, in which case you can cast `Value` to that type and use the following functions to get data:
 ```
 jsonObj->GetBool(key string)   bool
 jsonObj->GetInt(key string)    int
@@ -28,8 +29,7 @@ And also the number of entries by using:
 ```js
 jsonObject->GetLength()
 ```
-
-To get data out of JsonLists you can use these functions:
+If it's a JsonList you'd cast it to said type and use the following functions:
 ```js
 jsonLst->GetBool(index int)   bool
 jsonLst->GetInt(index int)    int
@@ -38,4 +38,6 @@ jsonLst->GetString(index int) string
 jsonLst->GetObject(index int) JsonObject
 jsonLst->GetList(index int)   JsonList
 ```
-And to get a JsonLists length you can use the `jsonLst->GetLength()` function
+And to get a JsonLists length you can use the `jsonLst->GetLength()` function.
+
+If the `Type` field matches a primitive then you may expect `Value` to be said primitive

--- a/README.md
+++ b/README.md
@@ -40,4 +40,5 @@ jsonLst->GetList(index int)   JsonList
 ```
 And to get a JsonLists length you can use the `jsonLst->GetLength()` function.
 
-If the `Type` field matches a primitive then you may expect `Value` to be said primitive
+If the `Type` field matches a primitive then you may expect `Value` to be a string which you can cast to said primitive.
+Due to differences in how ReCT and JSON handles types we cannot reliably have `Value` be of the specified object type, but casting from a string is rather easy.


### PR DESCRIPTION
JSON Spec says that JSON files are not required to have objects or arrays at the root. They can have bools, strings, numbers and so on.

This PR aims to provide that functionality to ReCTJson by simply changing a couple lines.

I have not tried to build the code nor have I tested it due to the situation the ReCT language finds itself in as of right now.

This should also fix #1 